### PR TITLE
Added optional silent install switch to Veil-Avasion when cloning

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -3,6 +3,7 @@
 # Global Variables
 gitcmd=$(which git)
 veildir=$(dirname ${0})
+unset veilopts
 
 # Title Function
 func_title(){
@@ -21,7 +22,7 @@ func_install(){
   cd ${veildir}
   echo '[*] Cloning Veil Framework Repos'
   ${gitcmd} clone https://github.com/Veil-Framework/Veil-Evasion.git
-  cd Veil-Evasion/setup && ./setup.sh
+  cd Veil-Evasion/setup && ./setup.sh ${veilopts:-}
   cd ../..
   ${gitcmd} clone https://github.com/Veil-Framework/PowerTools.git
   ${gitcmd} clone https://github.com/Veil-Framework/Veil-Pillage.git
@@ -63,7 +64,24 @@ func_update(){
 # Select Function and Menu Statement
 func_title
 case ${1} in
+  -s)
+    case ${2} in
+       -c)
+         veilopts="--silent"
+         ;;
+       *)
+         printf '%s\n' "[!] The -s switch is intended to be used with the -c \
+           (Clone) option." >&2
+         exit 3
+    esac
+    echo
+    func_install
+    ;;
   -c)
+    case ${2} in
+       -s)
+         veilopts="--silent"
+    esac
     echo
     func_install
     ;;
@@ -76,5 +94,6 @@ case ${1} in
     echo "[Usage]...: ${0} [OPTION]"
     echo '[Options].: -c = Clone Veil Framework Repos'
     echo '            -u = Update Veil Framework Repos'
+    echo '[Optional]: -s = Silent install of Veil-Evasion (with -c switch)'
     echo
 esac


### PR DESCRIPTION
Veil-Evasion's `setup.sh` already handles optional unattended installs (-s|--silent) logic. While one could simply echo `'y'` then pipe stdout to stdin, I believe this is a more proper way.