### PR TITLE
Fixes Ubuntu dependencies and permission issue

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -206,7 +206,7 @@ func_package_deps(){
   fi
 
   # Clone down the required install files
-  sudo -u "${trueuser}" git clone https://github.com/Veil-Framework/VeilDependencies.git
+  git clone https://github.com/Veil-Framework/VeilDependencies.git
   cd VeilDependencies
   mv * ..
   cd ..

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -158,7 +158,7 @@ func_package_deps(){
       if [ "${os}" != "ubuntu" ]; then
         sudo ${arg} apt-get -y -qq install wine wine64 wine32
       else # Special snowflakes... urghbuntu
-        sudo ${arg} apt-get -y -qq install wine-stable wine1.6 wine1.6-i386
+        sudo ${arg} apt-get -y -qq install wine wine1.6 wine1.6-i386
       fi
       tmp="$?"
       if [ "${tmp}" -ne "0" ]; then
@@ -284,12 +284,8 @@ func_package_deps(){
 
   # Start dependency install
   echo -e "\n\n [*] ${YELLOW}Installing dependencies${RESET}"
-  if [ "${os}" == "debian" ] || [ "${os}" == "kali" ] || [ "${os}" == "parrot" ]; then
+  if [ "${os}" == "debian" ] || [ "${os}" == "kali" ] || [ "${os}" == "parrot" ] || [ "${os}" == "ubuntu" ]; then
     sudo ${arg} apt-get -y install mingw-w64 monodoc-browser monodevelop mono-mcs wine unzip ruby golang wget git \
-      python python-crypto python-pefile python-pip ca-certificates python3-pip #ttf-mscorefonts-installer
-
-  elif [ "${os}" == "ubuntu" ]; then
-    sudo ${arg} apt-get -y install mingw-w64 monodoc-browser monodevelop mono-mcs wine-stable unzip ruby golang wget git \
       python python-crypto python-pefile python-pip ca-certificates python3-pip #ttf-mscorefonts-installer
 
   elif [ "${os}" == "fedora" ] || [ "${os}" == "rhel" ] || [ "${os}" == "centos" ]; then


### PR DESCRIPTION
This PR fixes two things:

* Ubuntu package for wine is now just `wine`, not `wine-stable`
* Removes `sudo -u "${trueuser}"` when cloning the VeilDependencies repo. This resolves issues when the install script is run as sudo in a directory that the trueuser doesn't have write access to.