### PR TITLE
Fixed dependencies on Arch Linux based distros and added BlackArch.

### DIFF
--- a/config/update.py
+++ b/config/update.py
@@ -58,7 +58,7 @@ def generateConfig(options):
     config += 'MSFVENOM_OPTIONS="' + options['MSFVENOM_OPTIONS'] + '"\n\n'
     print " [*] MSFVENOM_OPTIONS = " + options['MSFVENOM_OPTIONS']
 
-    config += '# The path to the metasploit framework, for example: /usr/share/metasploit-framework/\n'
+    config += '# The path to the metasploit framework, for example: /usr/share/metasploit-framework/\n\tArch Linux based distributions: /opt/metasploit\n'
     config += 'METASPLOIT_PATH="' + options['METASPLOIT_PATH'] + '"\n\n'
     print " [*] METASPLOIT_PATH = " + options['METASPLOIT_PATH']
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -12,7 +12,7 @@ arg=""
 errors=""
 outputfolder="/usr/share/veil-output"
 runuser="$(whoami)"
-if [ "${os}" == "ubuntu" ] || [ "${os}" == "arch" ] || [ "${os}" == "debian" ]; then
+if [ "${os}" == "ubuntu" ] || [ "${os}" == "arch" ] || [ "${os}" == "blackarch" ] || [ "${os}" == "debian" ]; then
   trueuser="$(who | tr -d '\n' | cut -d' ' -f1)"
 else
   trueuser="$(who am i | cut -d' ' -f1)" # If this is blank, we're actually root (kali)
@@ -191,7 +191,7 @@ func_package_deps(){
       errors="${errors}\n${msg}"
       echo -e " ${RED}[ERROR] ${msg}${RESET}\n"
     fi
-  elif [ "${os}" == "arch" ]; then
+  elif [ "${os}" == "arch" ] || [ "${os}" == "blackarch" ]; then
     if grep -Fxq "#[multilib]" /etc/pacman.conf; then
       echo "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
     fi
@@ -293,9 +293,9 @@ func_package_deps(){
       monodevelop mono-tools mono-core wine unzip ruby golang wget git python python-crypto python-pefile \
       python-pip ca-certificates msttcore-fonts-installer python3-pip winbind
 
-  elif [ "${os}" ==  "arch" ]; then
+  elif [ "${os}" ==  "arch" ] || [ "${os}" == "blackarch" ]; then
     sudo pacman -Sy ${arg} --needed mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-winpthreads \
-      mono mono-tools mono-addins python2-pip wget unzip ruby python python2 python-crypto gcc-go ca-certificates base-devel python3-pip winbind
+      mono mono-tools mono-addins python2-pip wget unzip ruby python python2 python-crypto gcc-go ca-certificates base-devel python-pip krb5 samba
     # Install pefile for python2 using pip, rather than via AUR as the package is currently broken.
     sudo pip2 install pefile
   fi
@@ -565,6 +565,8 @@ else
   os="$(awk -F '["=]' '/^ID=/ {print $2}' /etc/os-release 2>&- | cut -d'.' -f1)"
   if [ "${os}" == "arch" ]; then
     echo -e " [I] ${YELLOW}Arch Linux ${arch} detected...${RESET}\n"
+  elif [ "${os}" == "blackarch" ]; then
+	echo -e " [I] ${RED}BlackArch Linux ${arch} detected...${RESET}\n"
   elif [ "${os}" == "debian" ]; then
     echo -e " [!] ${RED}Debian Linux sid/TESTING ${arch} *possibly* detected..."
     echo -e "     If you are not currently running Debian Testing, you should exit this installer!${RESET}\n"


### PR DESCRIPTION
Hi!

I've made some changes to improve the installation process on Arch Linux based distributions:

The pacman command to install Arch Linux based distribution's dependencies is installing **python3-pip** which is installed by python-pip as you can see  in [Python pip in Arch Linux Packages](https://www.archlinux.org/packages/extra/any/python-pip/files/) and  **winbind** which is installed with samba in Arch Linux ([Linux Winbind Setup](https://wiki.pumpingstationone.org/Linux_Winbind_Setup#Arch_Linux)).

I've also added BlackArch Linux to the OS verification.