### PR TITLE
Change default compiling python method to py2exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Veil is current under support by @ChrisTruncer
 
 Run `./setup.sh -c` on Linux.
 
-Install Python 2.7, Py2Exe, PyCrypto, and PyWin32 on a Windows computer (for Py2Exe).
+### For Py2Exe
+
+> NOTE: Using Py2Exe is recommended over Pyinstaller for lower detection rate.
+
+Install [Python 2.7](https://www.python.org/ftp/python/2.7.14/python-2.7.14.msi), [Py2Exe](https://sourceforge.net/projects/py2exe/files/py2exe/0.6.9/), [PyCrypto](http://www.voidspace.org.uk/python/modules.shtml#pycrypto), and [PyWin32](https://sourceforge.net/projects/pywin32/files/pywin32/Build%20221/) on a Windows computer.
 
 ### Quick Install
 

--- a/Tools/Evasion/evasion_common/outfile.py
+++ b/Tools/Evasion/evasion_common/outfile.py
@@ -67,16 +67,16 @@ def compiler(payload_object, invoked=False, cli_object=None):
                         # if we have a linux distro, continue...
                         # Determine if the user wants Pyinstaller, Pwnstaller, or Py2Exe.
                         print('\n [?] How would you like to create your payload executable?\n')
-                        print('     %s - Pyinstaller %s' % (helpers.color('1'), helpers.color('(default)', yellow=True)))
-                        print('     %s - Py2Exe\n' % (helpers.color('2')))
+                        print('     %s - Py2Exe %s' % (helpers.color('1'), helpers.color('(default)', yellow=True)))
+                        print('     %s - Pyinstaller\n' % (helpers.color('2')))
 
                         user_compile_choice = input(" [>] Please enter the number of your choice: ")
                         if user_compile_choice == "1" or user_compile_choice == "":
-                            compile_method = "pyinstaller"
-                        elif user_compile_choice == "2":
                             compile_method = "py2exe"
-                        else:
+                        elif user_compile_choice == "2":
                             compile_method = "pyinstaller"
+                        else:
+                            compile_method = "py2exe"
 
                 if compile_method == 'py2exe' and payload_object.required_options['COMPILE_TO_EXE'][0].lower() == 'y':
                     # Generate setup.py File for Py2Exe


### PR DESCRIPTION
Pyinstaller has a much higher detection rate than py2exe. So by making py2exe default would encourage use of it.