### PR TITLE
print options properly

### DIFF
--- a/lib/common/orchestra.py
+++ b/lib/common/orchestra.py
@@ -201,7 +201,7 @@ class Conductor:
         print( " [i] Veil configuration file: /etc/veil/settings.py" )
         for i in dir(settings):
             if i.startswith('_'): continue
-            print( " [i] {0}: {1}".format( i , exec( "print ( settings." + i + " )" ) ), end='', flush=True)
+            print( " [i] {0}: {1}".format( i , eval( 'settings.' + str(i) )))
         input( '\n\nOptions shown. Press enter to continue' )
         return
 


### PR DESCRIPTION
the current ```options``` output is a mess (including bad practices programming):
```
Veil>: options
 [i] Veil configuration file: /etc/veil/settings.py
Linux
 [i] DISTRO: None/usr/lib/go/
 [i] GOLANG_PATH: None/usr/bin
 [i] METASPLOIT_PATH: None
 [i] MSFVENOM_OPTIONS: None/usr/bin/
 [i] MSFVENOM_PATH: NoneLinux
 [i] OPERATING_SYSTEM: None/tmp/
 [i] TEMP_PATH: Noneclear
 [i] TERMINAL_CLEAR: None/usr/lib/veil
 [i] VEIL_PATH: None
```

this patch fixes it:
```
 [i] Veil configuration file: /etc/veil/settings.py
 [i] DISTRO: Linux
 [i] GOLANG_PATH: /usr/lib/go/
 [i] METASPLOIT_PATH: /usr/bin
 [i] MSFVENOM_OPTIONS: 
 [i] MSFVENOM_PATH: /usr/bin/
 [i] OPERATING_SYSTEM: Linux
 [i] TEMP_PATH: /tmp/
 [i] TERMINAL_CLEAR: clear
 [i] VEIL_PATH: /usr/lib/veil
```

The better way would be to use the default ```configparser```
https://docs.python.org/3/library/configparser.html
