### PR TITLE
Fix installation of dependencies for Arch Linux

### DIFF
--- a/config/setup.sh
+++ b/config/setup.sh
@@ -391,15 +391,15 @@ func_package_deps(){
     {
       if [ $1 == 'yay' ]; then
         if [ "${silent}" == true ]; then
-          yay -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-gcc-base mingw-w64-winpthreads --noconfirm
+          yay -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-winpthreads --noconfirm
         else
-          yay -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-gcc-base mingw-w64-winpthreads
+          yay -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-winpthreads
         fi
       elif [ $1 == 'yaourt' ]; then
         if [ "${silent}" == true ]; then
-          yaourt -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-gcc-base mingw-w64-winpthreads --noconfirm
+          yaourt -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-winpthreads --noconfirm
         else
-          yaourt -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-gcc-base mingw-w64-winpthreads
+          yaourt -S mingw-w64-binutils mingw-w64-crt mingw-w64-gcc mingw-w64-headers mingw-w64-winpthreads
         fi
       fi
     }


### PR DESCRIPTION
Hi!

I've added another elif statement different than the blackarch one for arch linux since the current one uses the same process to install dependencies for both blackarch and arch, what's failing since some dependencies are being installed from blackarch repositories using pacman.

On the code I've added it's checking if yaourt or yay is installed and installing those dependencies from AUR repositories, installing yay in case that any of them is found and asking to remove it after the installation of the dependencies.