### PR TITLE
Fixed Fedora OS version read for setup script

### DIFF
--- a/config/setup.sh
+++ b/config/setup.sh
@@ -1027,6 +1027,7 @@ elif [ "${os}" == "debian" ]; then
   fi
 elif [ "${os}" == "fedora" ]; then
   echo -e " [I] ${YELLOW}Fedora ${osversion} ${arch} detected...${RESET}\n"
+  [[ -z "$osmajversion" ]] && osmajversion=$osversion
   if [[ "${osmajversion}" -lt "22" ]]; then
     echo -e " ${RED}[ERROR]: Veil is only supported on Fedora 22 or higher!${RESET}\n"
     exit 1


### PR DESCRIPTION
I ran into a bug that was easy to fix during the installation phase. Apparently, because of the changes in the  /etc/os-release file, the setup.sh script for veil doesn't correctly read the version string into $osmajversion, causing it to fail even though Fedora 29 is definitely higher than Fedora 22. 

A simple null-check on the $osmajversion and copying $osversion into it if it is empty fixes the issue. Just a quick fix, but thought I'd save you the trouble before someone submitted an issue.

I made sure to thoroughly test and installed Veil on Fedora 29 with no issues after this change.

Cheers 