### PR TITLE
ensure pip 19.1.x for python 3.4.x support

### DIFF
--- a/config/setup.sh
+++ b/config/setup.sh
@@ -784,7 +784,7 @@ func_python_deps(){
 
   ## Use wine based pip to install dependencies
   echo -e "\n\n [*] ${YELLOW}Installing (Wine) Python's PIP pefile${RESET}\n"
-  sudo -u "${trueuser}" WINEPREFIX="${winedir}" wine "${winedir}/drive_c/Python34/python.exe" "-m" "pip" "install" "--upgrade" "pip"
+  sudo -u "${trueuser}" WINEPREFIX="${winedir}" wine "${winedir}/drive_c/Python34/python.exe" "-m" "pip" "install" "--upgrade" "pip==19.1.*"
   tmp="$?"
   if [[ "${tmp}" -ne "0" ]]; then
     msg="Failed to run (wine) Python pip... Exit code: ${tmp}"


### PR DESCRIPTION
setup.sh upgrades pip to 20.x which breaks pip under Python 3.4.x:

```
 [*] Installing (Wine) Python's PIP pefile
[...]
Installing collected packages: pip
  Found existing installation: pip 7.1.2
    Uninstalling pip-7.1.2:
      Successfully uninstalled pip-7.1.2
Successfully installed pip-20.0.1
Traceback (most recent call last):
[...]
RuntimeError: Python 3.5 or later is required
```

Freezing pip to 19.1.* will ensure it continues to work with the Python 3.4.4 used by Veil -- via https://pip.pypa.io/en/stable/news/#id104.

(Tested on Kali Linux 64-Bit 2020.1)