### PR TITLE
Fix Installation error: Failed to run (wine) Python pip pefile

### DIFF
--- a/config/setup.sh
+++ b/config/setup.sh
@@ -811,7 +811,7 @@ func_python_deps(){
     echo -e " ${RED}[ERROR] ${msg}${RESET}\n"
   fi
 
-  sudo -u "${trueuser}" WINEPREFIX="${winedir}" wine "${winedir}/drive_c/Python34/python.exe" "-m" "pip" "install" "pefile"
+  sudo -u "${trueuser}" WINEPREFIX="${winedir}" wine "${winedir}/drive_c/Python34/python.exe" "-m" "pip" "install" "-Iv" "pefile==2019.4.18"
   tmp="$?"
   if [[ "${tmp}" -ne "0" ]]; then
     msg="Failed to run (wine) Python pip pefile... Exit code: ${tmp}"


### PR DESCRIPTION
This pull request fixes #471 #440 #475 #441 #428 

Veil uses Python 3.4, but the version of pefile grabbed by pip 19 uses f-string interpolation, which was not introduced until Python 3.6.

This is easily fixed by restricting the pip load of pefile to version 2019.4.18, which doesn't use f-strings.

It seems like lots of people have reported the installation failure, but have been told to make this change manually.

Nobody seems to have created a pull request to fix the issue, so here you are.